### PR TITLE
feat: Terraform ECS (Fargate)・ALBモジュール構築

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,6 +23,7 @@ tags: [索引, ドキュメント]
 | `docs/decisions/2026-03-12-vpc-network-module.md` | Terraform VPC・ネットワークモジュール構築 | ADR, Terraform, VPC, ネットワーク, セキュリティグループ |
 | `docs/decisions/2026-03-12-ecr-iam-oidc.md` | Terraform ECR・IAMロール・OIDC連携モジュール構築 | ADR, Terraform, ECR, IAM, OIDC, GitHub Actions |
 | `docs/decisions/2026-03-12-rds-secrets-manager.md` | Terraform RDS (PostgreSQL) モジュール・Secrets Manager連携 | ADR, Terraform, RDS, PostgreSQL, Secrets Manager |
+| `docs/decisions/2026-03-12-ecs-alb-module.md` | Terraform ECS (Fargate)・ALBモジュール構築 | ADR, Terraform, ECS, Fargate, ALB, CloudWatch |
 
 ## guidelines/
 

--- a/docs/decisions/2026-03-12-ecs-alb-module.md
+++ b/docs/decisions/2026-03-12-ecs-alb-module.md
@@ -1,0 +1,33 @@
+---
+title: Terraform ECS (Fargate)・ALBモジュール構築
+description: コンテナ実行基盤とロードバランサーの設計判断
+tags: [ADR, Terraform, ECS, Fargate, ALB, CloudWatch]
+---
+
+# Terraform ECS (Fargate)・ALBモジュール構築
+
+## 背景
+
+FastAPIアプリケーションをAWS上でコンテナとして実行するための基盤が必要。サーバーレスなコンテナ実行環境とHTTPトラフィック分散が要件。
+
+## 決定内容
+
+- **ECSクラスター**: Container Insights有効化でメトリクス可視化
+- **タスク定義**: Fargate、256 CPU / 512 MiB（dev最小構成）、Secrets Managerからの環境変数注入
+- **ECSサービス**: プライベートサブネットに配置、ALBと連携
+- **ALB**: パブリックサブネットに配置、`/health` でヘルスチェック
+- **CloudWatch Logs**: 環境別の保持期間（dev: 7日、prod: 30日）
+
+## 代替案
+
+| 案 | 却下理由 |
+|---|---------|
+| EC2ベースのECS | サーバー管理が必要。Fargateの方がサーバーレスで運用負荷が低い |
+| Lambda + API Gateway | コールドスタートが発生し、DB接続管理が煩雑 |
+| ECS Serviceなし（タスク直接実行） | ヘルスチェック・オートリカバリー・ローリングアップデートが使えない |
+
+## 結果
+
+- Fargateでサーバー管理不要のコンテナ実行環境を実現
+- ALBのヘルスチェックで異常タスクを自動的に置き換え
+- CloudWatch Logsでログを集約し、運用時の調査が容易

--- a/infra/modules/compute/main.tf
+++ b/infra/modules/compute/main.tf
@@ -1,0 +1,162 @@
+# ====================
+# CloudWatch Logs
+# ====================
+resource "aws_cloudwatch_log_group" "app" {
+  name              = "/ecs/${var.project_name}-${var.environment}"
+  retention_in_days = var.environment == "prod" ? 30 : 7
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-logs"
+  }
+}
+
+# ====================
+# ALB
+# ====================
+resource "aws_lb" "main" {
+  name               = "${var.project_name}-${var.environment}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.alb_security_group_id]
+  subnets            = var.public_subnet_ids
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-alb"
+  }
+}
+
+resource "aws_lb_target_group" "app" {
+  name        = "${var.project_name}-${var.environment}-tg"
+  port        = 8000
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-tg"
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+# ====================
+# ECS クラスター
+# ====================
+resource "aws_ecs_cluster" "main" {
+  name = "${var.project_name}-${var.environment}"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-cluster"
+  }
+}
+
+# ====================
+# ECS タスク定義
+# ====================
+resource "aws_ecs_task_definition" "app" {
+  family                   = "${var.project_name}-${var.environment}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = var.ecs_task_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "app"
+      image     = "${var.ecr_repository_url}:latest"
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 8000
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        {
+          name  = "APP_ENV"
+          value = var.environment
+        },
+        {
+          name  = "DEBUG"
+          value = var.environment == "dev" ? "true" : "false"
+        }
+      ]
+
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = "${var.db_secret_arn}:host::"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.app.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+    }
+  ])
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-task"
+  }
+}
+
+# ====================
+# ECS サービス
+# ====================
+resource "aws_ecs_service" "app" {
+  name            = "${var.project_name}-${var.environment}"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.ecs_security_group_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.app.arn
+    container_name   = "app"
+    container_port   = 8000
+  }
+
+  depends_on = [aws_lb_listener.http]
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-service"
+  }
+}

--- a/infra/modules/compute/outputs.tf
+++ b/infra/modules/compute/outputs.tf
@@ -1,0 +1,24 @@
+output "alb_dns_name" {
+  description = "ALBのDNS名"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_arn" {
+  description = "ALBのARN"
+  value       = aws_lb.main.arn
+}
+
+output "ecs_cluster_name" {
+  description = "ECSクラスター名"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "ecs_service_name" {
+  description = "ECSサービス名"
+  value       = aws_ecs_service.app.name
+}
+
+output "log_group_name" {
+  description = "CloudWatch Logsロググループ名"
+  value       = aws_cloudwatch_log_group.app.name
+}

--- a/infra/modules/compute/variables.tf
+++ b/infra/modules/compute/variables.tf
@@ -1,0 +1,78 @@
+variable "project_name" {
+  description = "プロジェクト名"
+  type        = string
+}
+
+variable "environment" {
+  description = "環境名"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "パブリックサブネットID（ALB用）"
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "プライベートサブネットID（ECS用）"
+  type        = list(string)
+}
+
+variable "alb_security_group_id" {
+  description = "ALB用セキュリティグループID"
+  type        = string
+}
+
+variable "ecs_security_group_id" {
+  description = "ECS用セキュリティグループID"
+  type        = string
+}
+
+variable "ecs_task_execution_role_arn" {
+  description = "ECSタスク実行ロールARN"
+  type        = string
+}
+
+variable "ecs_task_role_arn" {
+  description = "ECSタスクロールARN"
+  type        = string
+}
+
+variable "ecr_repository_url" {
+  description = "ECRリポジトリURL"
+  type        = string
+}
+
+variable "db_secret_arn" {
+  description = "DB接続情報のSecrets Manager ARN"
+  type        = string
+}
+
+variable "task_cpu" {
+  description = "タスクCPU（単位）"
+  type        = string
+  default     = "256"
+}
+
+variable "task_memory" {
+  description = "タスクメモリ（MiB）"
+  type        = string
+  default     = "512"
+}
+
+variable "desired_count" {
+  description = "ECSサービスのタスク数"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
## Summary
- ECSクラスター（Container Insights有効）+ Fargateタスク定義 + ECSサービス
- ALB + ターゲットグループ + HTTPリスナー（/healthヘルスチェック）
- CloudWatch Logsロググループ（dev: 7日、prod: 30日保持）
- Secrets Managerからの環境変数注入
- ADR: `docs/decisions/2026-03-12-ecs-alb-module.md`

## 関連Issue
closes #8

## Test plan
- [ ] `terraform validate` がパスすること
- [ ] モジュール間の変数参照が整合していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)