### PR TITLE
feat: CDパイプライン構築（Terraform Plan・tflint・tfsec）

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,119 @@
+name: CD (Terraform)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "infra/**"
+      - ".github/workflows/cd.yml"
+  push:
+    branches: [main]
+    paths:
+      - "infra/**"
+      - ".github/workflows/cd.yml"
+
+env:
+  TF_VERSION: "1.5.7"
+  WORKING_DIR: infra/environments/dev
+
+jobs:
+  fmt:
+    name: Terraform Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive
+        working-directory: infra
+
+  validate:
+    name: Terraform Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+      - name: Terraform init
+        run: terraform init -backend=false
+        working-directory: ${{ env.WORKING_DIR }}
+      - name: Terraform validate
+        run: terraform validate
+        working-directory: ${{ env.WORKING_DIR }}
+
+  tflint:
+    name: TFLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: latest
+      - name: Init TFLint
+        run: tflint --init
+        working-directory: ${{ env.WORKING_DIR }}
+      - name: Run TFLint
+        run: tflint --recursive
+        working-directory: infra
+
+  tfsec:
+    name: tfsec (Security Scan)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: tfsec
+        uses: aquasecurity/tfsec-action@v1.0.3
+        with:
+          working_directory: infra
+
+  plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs: [fmt, validate]
+    permissions:
+      pull-requests: write
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform init
+        run: terraform init -backend=false
+        working-directory: ${{ env.WORKING_DIR }}
+
+      - name: Terraform plan
+        id: plan
+        run: terraform plan -no-color -input=false 2>&1 | tee plan.txt || true
+        working-directory: ${{ env.WORKING_DIR }}
+        continue-on-error: true
+
+      - name: Comment PR with plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('${{ env.WORKING_DIR }}/plan.txt', 'utf8');
+            const truncated = plan.length > 60000 ? plan.substring(0, 60000) + '\n...(truncated)' : plan;
+
+            const body = `## Terraform Plan 結果
+            <details>
+            <summary>Plan出力（クリックで展開）</summary>
+
+            \`\`\`
+            ${truncated}
+            \`\`\`
+            </details>`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,6 +24,7 @@ tags: [索引, ドキュメント]
 | `docs/decisions/2026-03-12-ecr-iam-oidc.md` | Terraform ECR・IAMロール・OIDC連携モジュール構築 | ADR, Terraform, ECR, IAM, OIDC, GitHub Actions |
 | `docs/decisions/2026-03-12-rds-secrets-manager.md` | Terraform RDS (PostgreSQL) モジュール・Secrets Manager連携 | ADR, Terraform, RDS, PostgreSQL, Secrets Manager |
 | `docs/decisions/2026-03-12-ecs-alb-module.md` | Terraform ECS (Fargate)・ALBモジュール構築 | ADR, Terraform, ECS, Fargate, ALB, CloudWatch |
+| `docs/decisions/2026-03-12-cd-pipeline.md` | CDパイプライン構築（Terraform Plan・IaC静的解析） | ADR, CI/CD, Terraform, tflint, tfsec, GitHub Actions |
 
 ## guidelines/
 

--- a/docs/decisions/2026-03-12-cd-pipeline.md
+++ b/docs/decisions/2026-03-12-cd-pipeline.md
@@ -1,0 +1,34 @@
+---
+title: CDパイプライン構築（Terraform Plan・IaC静的解析）
+description: インフラコードの品質チェックとPlan自動化の設計判断
+tags: [ADR, CI/CD, Terraform, tflint, tfsec, GitHub Actions]
+---
+
+# CDパイプライン構築（Terraform Plan・IaC静的解析）
+
+## 背景
+
+Terraformコードの変更がインフラに与える影響を事前に可視化し、セキュリティリスクを自動検出する仕組みが必要だった。
+
+## 決定内容
+
+- **ワークフロー構成**: 5ジョブ（fmt / validate / tflint / tfsec / plan）
+- **トリガー**: `infra/` 配下の変更時のみ（pathsフィルター）
+- **Terraform Plan**: PRコメントに結果を自動投稿し、変更内容を可視化
+- **tflint**: Terraformのベストプラクティス・構文チェック
+- **tfsec**: インフラコードのセキュリティ脆弱性スキャン
+- **バックエンド**: `init -backend=false` でCI上ではステート接続なしで実行
+
+## 代替案
+
+| 案 | 却下理由 |
+|---|---------|
+| Plan結果をログのみに出力 | PRコメントの方がレビュー時に確認しやすい |
+| Terraform CloudのSpeculative Plan | 無料枠制限あり、GitHub Actionsの方が柔軟 |
+| tfsecの代わりにcheckov | tfsecの方がTerraform特化で設定が簡潔 |
+
+## 結果
+
+- PR上でインフラ変更の影響を即座に確認可能
+- tflint/tfsecでセキュリティ・ベストプラクティスを自動担保
+- `infra/` 以外の変更ではワークフローが実行されず効率的


### PR DESCRIPTION
## Summary
- `cd.yml`: fmt/validate/tflint/tfsec/planの5ジョブ構成
- PRコメントにTerraform Plan結果を自動投稿
- `infra/`配下の変更時のみトリガー（pathsフィルター）
- ADR: `docs/decisions/2026-03-12-cd-pipeline.md`

## 関連Issue
closes #10

## Test plan
- [ ] infra変更時にCDワークフローがトリガーされること
- [ ] PRコメントにPlan結果が投稿されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)