### PR TITLE
feat: デプロイワークフロー構築（ECR→ECS・Terraform apply）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,160 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "app/**"
+      - "Dockerfile"
+      - "pyproject.toml"
+
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "デプロイ先環境"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - prod
+
+env:
+  AWS_REGION: ap-northeast-1
+
+jobs:
+  build-and-push:
+    name: Build & Push to ECR
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'dev' }}
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      image_uri: ${{ steps.build.outputs.image_uri }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image
+        id: build
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          IMAGE_URI="${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+          docker build -t "${IMAGE_URI}" .
+          docker tag "${IMAGE_URI}" "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+          docker push "${IMAGE_URI}"
+          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+          echo "image_uri=${IMAGE_URI}" >> "$GITHUB_OUTPUT"
+
+  migrate:
+    name: Run Migrations
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    environment: ${{ github.event.inputs.environment || 'dev' }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Run Alembic migration via ECS Run Task
+        env:
+          CLUSTER: ${{ vars.ECS_CLUSTER }}
+          TASK_DEFINITION: ${{ vars.ECS_TASK_DEFINITION }}
+          SUBNETS: ${{ vars.PRIVATE_SUBNETS }}
+          SECURITY_GROUPS: ${{ vars.ECS_SECURITY_GROUPS }}
+        run: |
+          aws ecs run-task \
+            --cluster "${CLUSTER}" \
+            --task-definition "${TASK_DEFINITION}" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[${SUBNETS}],securityGroups=[${SECURITY_GROUPS}],assignPublicIp=DISABLED}" \
+            --overrides '{"containerOverrides":[{"name":"app","command":["alembic","upgrade","head"]}]}' \
+            --query 'tasks[0].taskArn' \
+            --output text
+
+  deploy:
+    name: Deploy to ECS
+    runs-on: ubuntu-latest
+    needs: [build-and-push, migrate]
+    environment: ${{ github.event.inputs.environment || 'dev' }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update ECS service
+        env:
+          CLUSTER: ${{ vars.ECS_CLUSTER }}
+          SERVICE: ${{ vars.ECS_SERVICE }}
+        run: |
+          aws ecs update-service \
+            --cluster "${CLUSTER}" \
+            --service "${SERVICE}" \
+            --force-new-deployment \
+            --query 'service.serviceName' \
+            --output text
+
+      - name: Wait for deployment
+        env:
+          CLUSTER: ${{ vars.ECS_CLUSTER }}
+          SERVICE: ${{ vars.ECS_SERVICE }}
+        run: |
+          aws ecs wait services-stable \
+            --cluster "${CLUSTER}" \
+            --services "${SERVICE}"
+
+  terraform-apply:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    environment: ${{ github.event.inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      TF_VERSION: "1.5.7"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform init
+        run: terraform init
+        working-directory: infra/environments/${{ github.event.inputs.environment }}
+
+      - name: Terraform apply
+        run: terraform apply -auto-approve -input=false
+        working-directory: infra/environments/${{ github.event.inputs.environment }}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,6 +25,7 @@ tags: [索引, ドキュメント]
 | `docs/decisions/2026-03-12-rds-secrets-manager.md` | Terraform RDS (PostgreSQL) モジュール・Secrets Manager連携 | ADR, Terraform, RDS, PostgreSQL, Secrets Manager |
 | `docs/decisions/2026-03-12-ecs-alb-module.md` | Terraform ECS (Fargate)・ALBモジュール構築 | ADR, Terraform, ECS, Fargate, ALB, CloudWatch |
 | `docs/decisions/2026-03-12-cd-pipeline.md` | CDパイプライン構築（Terraform Plan・IaC静的解析） | ADR, CI/CD, Terraform, tflint, tfsec, GitHub Actions |
+| `docs/decisions/2026-03-12-deploy-workflow.md` | デプロイワークフロー構築（ECR→ECS・Terraform apply） | ADR, CI/CD, GitHub Actions, ECS, ECR, Terraform, Alembic |
 
 ## guidelines/
 

--- a/docs/decisions/2026-03-12-deploy-workflow.md
+++ b/docs/decisions/2026-03-12-deploy-workflow.md
@@ -1,0 +1,36 @@
+---
+title: デプロイワークフロー構築（ECR→ECS・Terraform apply）
+description: アプリケーションデプロイとインフラ適用の自動化設計判断
+tags: [ADR, CI/CD, GitHub Actions, ECS, ECR, Terraform, Alembic]
+---
+
+# デプロイワークフロー構築（ECR→ECS・Terraform apply）
+
+## 背景
+
+アプリケーションコードの変更を本番環境に安全にデプロイし、インフラ変更も制御されたフローで適用する仕組みが必要だった。
+
+## 決定内容
+
+- **アプリデプロイ（自動）**: mainプッシュ時に `build-and-push` → `migrate` → `deploy` の3ステージで実行
+  - Dockerイメージビルド → ECRプッシュ（コミットSHA + latestタグ）
+  - Alembicマイグレーション: ECS Run Taskで `alembic upgrade head` を実行（デプロイ前）
+  - ECSサービス更新: `force-new-deployment` でローリングアップデート + `services-stable` で完了待ち
+- **Terraform Apply（手動）**: `workflow_dispatch` で環境を選択して手動実行
+- **認証**: GitHub Actions OIDC（長期クレデンシャル不要）
+- **環境分離**: GitHub Environments で dev/prod を分離（prod は承認ゲート設定可能）
+
+## 代替案
+
+| 案 | 却下理由 |
+|---|---------|
+| マイグレーションをDockerエントリーポイントで実行 | 複数タスク起動時に競合する。ECS Run Taskで単発実行の方が安全 |
+| Terraform ApplyもmainプッシュでFself動実行 | インフラ変更は影響が大きいため、手動トリガー+承認の方が安全 |
+| CodePipeline / CodeDeploy | GitHub Actionsで完結する方がシンプル。追加のAWSサービス管理不要 |
+
+## 結果
+
+- アプリ変更は自動デプロイで迅速にリリース
+- マイグレーションがデプロイ前に確実に実行される順序制御
+- インフラ変更は手動トリガーで安全に適用
+- OIDCにより認証情報の管理が不要


### PR DESCRIPTION
## Summary
- `deploy.yml`: build→migrate→deployの3ステージ自動デプロイ
- Alembicマイグレーション: ECS Run Taskでデプロイ前に実行
- Terraform Apply: workflow_dispatchで手動トリガー（環境選択・承認ゲート対応）
- OIDC認証・GitHub Environments対応
- ADR: `docs/decisions/2026-03-12-deploy-workflow.md`

## 関連Issue
closes #13

## Test plan
- [ ] mainプッシュ時にデプロイワークフローがトリガーされること
- [ ] workflow_dispatchで環境を選択してTerraform Applyが実行できること
- [ ] マイグレーション→デプロイの順序が保証されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)