### PR TITLE
feat: APIクライアント構築（FastAPIバックエンド連携）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,6 +29,7 @@ tags: [索引, ドキュメント]
 | `docs/decisions/2026-03-12-deploy-workflow.md` | デプロイワークフロー構築（ECR→ECS・Terraform apply） | ADR, CI/CD, GitHub Actions, ECS, ECR, Terraform, Alembic |
 | `docs/decisions/2026-03-12-nextjs-initial-setup.md` | Next.js (App Router) 初期セットアップ | ADR, Next.js, TypeScript, ESLint, Prettier, フロントエンド |
 | `docs/decisions/2026-03-12-tailwind-css-setup.md` | Tailwind CSS 導入・デザインシステム基盤 | ADR, Tailwind CSS, フロントエンド, デザイン |
+| `docs/decisions/2026-03-12-api-client.md` | APIクライアント構築（FastAPIバックエンド連携） | ADR, フロントエンド, API, TypeScript, fetch |
 
 ## guidelines/
 

--- a/docs/decisions/2026-03-12-api-client.md
+++ b/docs/decisions/2026-03-12-api-client.md
@@ -1,0 +1,34 @@
+---
+title: APIクライアント構築（FastAPIバックエンド連携）
+description: フロントエンドからバックエンドへの型安全な通信基盤の設計判断
+tags: [ADR, フロントエンド, API, TypeScript, fetch]
+---
+
+# APIクライアント構築（FastAPIバックエンド連携）
+
+## 背景
+
+Next.js フロントエンドから FastAPI バックエンドの `/tasks` エンドポイントに型安全に通信する基盤が必要だった。
+
+## 決定内容
+
+- **APIクライアント**: `fetch` ベースの軽量クライアント（`src/lib/api.ts`）
+- **型定義**: バックエンドの Pydantic スキーマと同期した TypeScript 型（`src/types/task.ts`）
+- **エラーハンドリング**: `ApiError` クラスでHTTPステータスとメッセージを構造化
+- **環境変数**: `NEXT_PUBLIC_API_URL` でAPI接続先を設定可能
+- **API構造**: `taskApi` オブジェクトに CRUD メソッドを集約
+
+## 代替案
+
+| 案 | 却下理由 |
+|---|---------|
+| axios | fetch が標準API。追加依存を増やす必要がない |
+| tRPC | バックエンドが FastAPI (Python) のため TypeScript 前提の tRPC は不適 |
+| OpenAPI Generator で自動生成 | 導入コストが高い。MVPでは手動同期で十分 |
+| SWR / TanStack Query | Server Components 主体のため、クライアント側キャッシュは現時点で不要 |
+
+## 結果
+
+- fetch ベースで追加依存なし。Server Components / Server Actions からも利用可能
+- 型定義により、APIレスポンスの型安全性を確保
+- `ApiError` で統一的なエラーハンドリングが可能

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,65 @@
+import type { Task, TaskCreate, TaskUpdate } from "@/types/task";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function fetchApi<T>(
+  path: string,
+  options?: RequestInit,
+): Promise<T> {
+  const url = `${API_BASE_URL}${path}`;
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => res.statusText);
+    throw new ApiError(res.status, detail);
+  }
+
+  if (res.status === 204) {
+    return undefined as T;
+  }
+
+  return res.json() as Promise<T>;
+}
+
+export const taskApi = {
+  list: (skip = 0, limit = 100) =>
+    fetchApi<Task[]>(`/tasks?skip=${skip}&limit=${limit}`),
+
+  get: (id: number) => fetchApi<Task>(`/tasks/${id}`),
+
+  create: (data: TaskCreate) =>
+    fetchApi<Task>("/tasks", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+
+  update: (id: number, data: TaskUpdate) =>
+    fetchApi<Task>(`/tasks/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
+
+  delete: (id: number) =>
+    fetchApi<void>(`/tasks/${id}`, {
+      method: "DELETE",
+    }),
+};
+
+export { ApiError };

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -1,0 +1,22 @@
+export type TaskStatus = "todo" | "in_progress" | "done";
+
+export interface Task {
+  id: number;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TaskCreate {
+  title: string;
+  description?: string | null;
+  status?: TaskStatus;
+}
+
+export interface TaskUpdate {
+  title?: string | null;
+  description?: string | null;
+  status?: TaskStatus | null;
+}


### PR DESCRIPTION
## Summary
- `src/types/task.ts`: バックエンドPydanticスキーマと同期したTypeScript型定義
- `src/lib/api.ts`: fetchベースの型安全APIクライアント（CRUD全操作 + ApiError）
- `.gitignore`: `lib/` パスをルート限定に修正
- ADR: `docs/decisions/2026-03-12-api-client.md`

## 関連Issue
closes #32

## Test plan
- [ ] 型定義がバックエンドのスキーマと一致すること
- [ ] CI が通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)