### PR TITLE
feat: タスク管理UI実装（一覧・作成・更新・削除） #33

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,6 +30,7 @@ tags: [索引, ドキュメント]
 | `docs/decisions/2026-03-12-nextjs-initial-setup.md` | Next.js (App Router) 初期セットアップ | ADR, Next.js, TypeScript, ESLint, Prettier, フロントエンド |
 | `docs/decisions/2026-03-12-tailwind-css-setup.md` | Tailwind CSS 導入・デザインシステム基盤 | ADR, Tailwind CSS, フロントエンド, デザイン |
 | `docs/decisions/2026-03-12-api-client.md` | APIクライアント構築（FastAPIバックエンド連携） | ADR, フロントエンド, API, TypeScript, fetch |
+| `docs/decisions/2026-03-12-task-management-ui.md` | タスク管理UI実装（一覧・作成・更新・削除） | ADR, Next.js, App Router, Server Components, Server Actions, UI |
 
 ## guidelines/
 

--- a/docs/decisions/2026-03-12-task-management-ui.md
+++ b/docs/decisions/2026-03-12-task-management-ui.md
@@ -1,0 +1,35 @@
+---
+title: タスク管理UI実装（一覧・作成・更新・削除）
+description: App RouterベースのタスクCRUD UIの設計判断
+tags: [ADR, Next.js, App Router, Server Components, Server Actions, UI]
+---
+
+# タスク管理UI実装（一覧・作成・更新・削除）
+
+## 背景
+
+バックエンドのタスク管理CRUD APIに対応するフロントエンドUIが必要だった。App Routerの機能（Server Components, Server Actions）を活用した設計が求められた。
+
+## 決定内容
+
+- **一覧ページ** (`/tasks`): Server Componentでデータ取得、`loading.tsx`/`error.tsx`で状態表示
+- **作成ページ** (`/tasks/new`): TaskFormコンポーネント + Server Actions
+- **詳細・編集ページ** (`/tasks/[id]`): 動的ルートでタスク取得・更新
+- **削除**: 確認ダイアログ付きのClient Componentボタン + Server Actions
+- **共通コンポーネント**: TaskStatusBadge（ステータス表示）、TaskForm（作成/編集兼用）、DeleteButton
+- **Server Actions**: `actions.ts` に集約し、`revalidatePath` でキャッシュ再検証
+
+## 代替案
+
+| 案 | 却下理由 |
+|---|---------|
+| Client Componentで全UI構築 | Server Componentsの利点（初回表示速度・SEO）を活かせない |
+| Route Handler (API Routes) 経由 | Server Actionsの方がフォーム送信がシンプル |
+| 一覧と編集を同一ページ（モーダル） | App Routerのファイルベースルーティングを活かす方がコードが明確 |
+
+## 結果
+
+- Server Componentsで初回表示が高速
+- Server Actionsでフォーム送信がシームレス（クライアントJSの削減）
+- `loading.tsx`/`error.tsx`でUXが向上（App Router標準パターン）
+- TaskFormコンポーネントが作成/編集で再利用されコードが簡潔

--- a/frontend/src/app/tasks/[id]/page.tsx
+++ b/frontend/src/app/tasks/[id]/page.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { taskApi } from "@/lib/api";
+import { updateTask, deleteTask } from "../actions";
+import { TaskForm } from "@/components/task-form";
+import { DeleteButton } from "@/components/delete-button";
+
+export const dynamic = "force-dynamic";
+
+export default async function TaskDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const taskId = Number(id);
+  const task = await taskApi.get(taskId);
+
+  const updateTaskWithId = updateTask.bind(null, taskId);
+  const deleteTaskWithId = deleteTask.bind(null, taskId);
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link href="/tasks" className="text-gray-500 hover:text-gray-700">
+            ← 戻る
+          </Link>
+          <h1 className="text-2xl font-bold">タスク編集</h1>
+        </div>
+        <DeleteButton action={deleteTaskWithId} />
+      </div>
+      <TaskForm action={updateTaskWithId} defaultValues={task} />
+    </div>
+  );
+}

--- a/frontend/src/app/tasks/actions.ts
+++ b/frontend/src/app/tasks/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+import { taskApi } from "@/lib/api";
+import type { TaskStatus } from "@/types/task";
+
+export async function createTask(formData: FormData) {
+  const title = formData.get("title") as string;
+  const description = (formData.get("description") as string) || null;
+  const status = (formData.get("status") as TaskStatus) || "todo";
+
+  await taskApi.create({ title, description, status });
+  redirect("/tasks");
+}
+
+export async function updateTask(id: number, formData: FormData) {
+  const title = formData.get("title") as string;
+  const description = (formData.get("description") as string) || null;
+  const status = formData.get("status") as TaskStatus;
+
+  await taskApi.update(id, { title, description, status });
+  revalidatePath("/tasks");
+  redirect("/tasks");
+}
+
+export async function deleteTask(id: number) {
+  await taskApi.delete(id);
+  revalidatePath("/tasks");
+  redirect("/tasks");
+}

--- a/frontend/src/app/tasks/error.tsx
+++ b/frontend/src/app/tasks/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+export default function TasksError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <p className="text-danger">エラーが発生しました: {error.message}</p>
+      <button
+        onClick={reset}
+        className="rounded-lg bg-primary px-4 py-2 text-sm text-white hover:bg-primary-dark"
+      >
+        再試行
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/tasks/loading.tsx
+++ b/frontend/src/app/tasks/loading.tsx
@@ -1,0 +1,7 @@
+export default function TasksLoading() {
+  return (
+    <div className="flex items-center justify-center py-20">
+      <p className="text-gray-500">読み込み中...</p>
+    </div>
+  );
+}

--- a/frontend/src/app/tasks/new/page.tsx
+++ b/frontend/src/app/tasks/new/page.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+import { createTask } from "../actions";
+import { TaskForm } from "@/components/task-form";
+
+export default function NewTaskPage() {
+  return (
+    <div>
+      <div className="mb-6 flex items-center gap-4">
+        <Link href="/tasks" className="text-gray-500 hover:text-gray-700">
+          ← 戻る
+        </Link>
+        <h1 className="text-2xl font-bold">タスク作成</h1>
+      </div>
+      <TaskForm action={createTask} />
+    </div>
+  );
+}

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { taskApi } from "@/lib/api";
+import { TaskStatusBadge } from "@/components/task-status-badge";
+
+export const dynamic = "force-dynamic";
+
+export default async function TasksPage() {
+  const tasks = await taskApi.list();
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">タスク一覧</h1>
+        <Link
+          href="/tasks/new"
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-dark"
+        >
+          新規作成
+        </Link>
+      </div>
+
+      {tasks.length === 0 ? (
+        <p className="text-gray-500">タスクがありません</p>
+      ) : (
+        <ul className="space-y-3">
+          {tasks.map((task) => (
+            <li key={task.id}>
+              <Link
+                href={`/tasks/${task.id}`}
+                className="block rounded-lg border border-border bg-white p-4 transition hover:shadow-md"
+              >
+                <div className="flex items-center justify-between">
+                  <h2 className="font-semibold">{task.title}</h2>
+                  <TaskStatusBadge status={task.status} />
+                </div>
+                {task.description && (
+                  <p className="mt-2 text-sm text-gray-600">
+                    {task.description}
+                  </p>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/delete-button.tsx
+++ b/frontend/src/components/delete-button.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+interface DeleteButtonProps {
+  action: () => Promise<void>;
+}
+
+export function DeleteButton({ action }: DeleteButtonProps) {
+  const handleDelete = async () => {
+    if (!confirm("このタスクを削除しますか？")) return;
+    await action();
+  };
+
+  return (
+    <button
+      onClick={handleDelete}
+      className="rounded-lg bg-danger px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+    >
+      削除
+    </button>
+  );
+}

--- a/frontend/src/components/task-form.tsx
+++ b/frontend/src/components/task-form.tsx
@@ -1,0 +1,63 @@
+import type { Task } from "@/types/task";
+
+interface TaskFormProps {
+  action: (formData: FormData) => Promise<void>;
+  defaultValues?: Task;
+}
+
+export function TaskForm({ action, defaultValues }: TaskFormProps) {
+  return (
+    <form action={action} className="space-y-4 rounded-lg border border-border bg-white p-6">
+      <div>
+        <label htmlFor="title" className="block text-sm font-medium">
+          タイトル
+        </label>
+        <input
+          id="title"
+          name="title"
+          type="text"
+          required
+          maxLength={255}
+          defaultValue={defaultValues?.title}
+          className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="description" className="block text-sm font-medium">
+          説明
+        </label>
+        <textarea
+          id="description"
+          name="description"
+          rows={4}
+          defaultValue={defaultValues?.description ?? ""}
+          className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="status" className="block text-sm font-medium">
+          ステータス
+        </label>
+        <select
+          id="status"
+          name="status"
+          defaultValue={defaultValues?.status ?? "todo"}
+          className="mt-1 w-full rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+        >
+          <option value="todo">未着手</option>
+          <option value="in_progress">進行中</option>
+          <option value="done">完了</option>
+        </select>
+      </div>
+
+      <button
+        type="submit"
+        className="rounded-lg bg-primary px-6 py-2 text-sm font-medium text-white hover:bg-primary-dark"
+      >
+        {defaultValues ? "更新" : "作成"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/task-status-badge.tsx
+++ b/frontend/src/components/task-status-badge.tsx
@@ -1,0 +1,28 @@
+import type { TaskStatus } from "@/types/task";
+
+const statusConfig: Record<TaskStatus, { label: string; className: string }> = {
+  todo: {
+    label: "未着手",
+    className: "bg-gray-100 text-gray-700",
+  },
+  in_progress: {
+    label: "進行中",
+    className: "bg-blue-100 text-blue-700",
+  },
+  done: {
+    label: "完了",
+    className: "bg-green-100 text-green-700",
+  },
+};
+
+export function TaskStatusBadge({ status }: { status: TaskStatus }) {
+  const config = statusConfig[status];
+
+  return (
+    <span
+      className={`rounded-full px-3 py-1 text-xs font-medium ${config.className}`}
+    >
+      {config.label}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Server Componentベースのタスク一覧ページ（`/tasks`）、作成ページ（`/tasks/new`）、詳細・編集ページ（`/tasks/[id]`）を実装
- Server Actions（`actions.ts`）でフォーム送信・削除処理を集約、`revalidatePath`でキャッシュ再検証
- 共通コンポーネント（TaskForm, TaskStatusBadge, DeleteButton）で再利用性を確保
- `loading.tsx`/`error.tsx`でApp Router標準のUXパターンを適用

## Test plan
- [ ] `/tasks` でタスク一覧が表示されること
- [ ] `/tasks/new` でタスク作成後、一覧にリダイレクトされること
- [ ] `/tasks/[id]` でタスク編集・更新ができること
- [ ] 削除ボタンで確認ダイアログ表示後、削除されること
- [ ] ローディング・エラー状態が正しく表示されること

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)