### PR TITLE
feat: Terraform OpenAI APIキー管理（Secrets Manager・ECS連携） #40

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ POSTGRES_DB=taskdb
 # Application
 APP_ENV=development
 DEBUG=true
+
+# OpenAI
+OPENAI_API_KEY=sk-your-api-key-here
+OPENAI_MODEL=gpt-4o-mini

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "8000:8000"
     volumes:
       - .:/app
+    env_file:
+      - .env
     environment:
       - DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/taskdb
       - APP_ENV=development

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,6 +33,7 @@ tags: [索引, ドキュメント]
 | `docs/decisions/2026-03-12-task-management-ui.md` | タスク管理UI実装（一覧・作成・更新・削除） | ADR, Next.js, App Router, Server Components, Server Actions, UI |
 | `docs/decisions/2026-03-12-frontend-test-foundation.md` | フロントエンドテスト基盤構築（Vitest + Testing Library） | ADR, Vitest, Testing Library, MSW, フロントエンド, テスト |
 | `docs/decisions/2026-03-12-openai-api-integration.md` | OpenAI API統合方針（タスク解説機能） | ADR, OpenAI, FastAPI, SSE, ストリーミング, DI, セキュリティ |
+| `docs/decisions/2026-03-12-terraform-openai-secret.md` | Terraform OpenAI APIキー管理（Secrets Manager・ECS連携） | ADR, Terraform, Secrets Manager, ECS, OpenAI, セキュリティ |
 
 ## guidelines/
 

--- a/docs/decisions/2026-03-12-terraform-openai-secret.md
+++ b/docs/decisions/2026-03-12-terraform-openai-secret.md
@@ -1,0 +1,33 @@
+---
+title: Terraform OpenAI APIキー管理（Secrets Manager・ECS連携）
+description: OpenAI APIキーをSecrets Manager経由でECS Fargateコンテナに注入するインフラ構成の設計判断
+tags: [ADR, Terraform, Secrets Manager, ECS, OpenAI, セキュリティ]
+---
+
+# Terraform OpenAI APIキー管理（Secrets Manager・ECS連携）
+
+## 背景
+
+OpenAI API統合（#39 ADR）において、APIキーを安全にECS Fargateコンテナへ渡す仕組みが必要だった。既存のSecrets Manager運用（RDS接続情報）と統一した方式で管理する。
+
+## 決定内容
+
+- **computeモジュール**: `openai_secret_arn` 変数を追加、ECSタスク定義の `secrets` ブロックで `OPENAI_API_KEY` として注入
+- **条件付き注入**: `openai_secret_arn` が空文字の場合はsecretsに含めない（既存環境への影響なし）
+- **IAMモジュール**: 既存の `secrets_arns` リストにOpenAIシークレットARNを追加するだけで権限付与される設計（変更不要）
+- **ローカル開発**: `docker-compose.yml` で `env_file: .env` を追加し、`.env` から `OPENAI_API_KEY` を読み込み
+- **`.env.example`**: `OPENAI_API_KEY` と `OPENAI_MODEL` のプレースホルダーを追加
+
+## 代替案
+
+| 案 | 却下理由 |
+|---|---------|
+| 環境変数ハードコード | セキュリティリスク、シークレットのローテーション不可 |
+| SSM Parameter Store | Secrets Managerの方が自動ローテーション対応、既存RDSと統一 |
+| 専用のsecretsモジュール新設 | 既存IAMモジュールの `secrets_arns` で十分対応可能 |
+
+## 結果
+
+- 既存IAM権限モデルと統合され、追加のIAMポリシー変更が不要
+- `openai_secret_arn` のデフォルト空文字により、既存環境に影響なし
+- ローカル開発でも `.env` から同じ環境変数名で利用可能

--- a/infra/modules/compute/main.tf
+++ b/infra/modules/compute/main.tf
@@ -109,12 +109,20 @@ resource "aws_ecs_task_definition" "app" {
         }
       ]
 
-      secrets = [
-        {
-          name      = "DATABASE_URL"
-          valueFrom = "${var.db_secret_arn}:host::"
-        }
-      ]
+      secrets = concat(
+        [
+          {
+            name      = "DATABASE_URL"
+            valueFrom = "${var.db_secret_arn}:host::"
+          }
+        ],
+        var.openai_secret_arn != "" ? [
+          {
+            name      = "OPENAI_API_KEY"
+            valueFrom = var.openai_secret_arn
+          }
+        ] : []
+      )
 
       logConfiguration = {
         logDriver = "awslogs"

--- a/infra/modules/compute/variables.tf
+++ b/infra/modules/compute/variables.tf
@@ -59,6 +59,12 @@ variable "db_secret_arn" {
   type        = string
 }
 
+variable "openai_secret_arn" {
+  description = "OpenAI APIキーのSecrets Manager ARN"
+  type        = string
+  default     = ""
+}
+
 variable "task_cpu" {
   description = "タスクCPU（単位）"
   type        = string


### PR DESCRIPTION
## Summary
- ECSタスク定義に`OPENAI_API_KEY`のSecrets Manager参照を条件付きで追加（`openai_secret_arn`空文字時は注入しない）
- `docker-compose.yml`に`env_file: .env`を追加し、ローカル開発でもOpenAI APIキーを利用可能に
- `.env.example`に`OPENAI_API_KEY`・`OPENAI_MODEL`のプレースホルダーを追加

## Test plan
- [ ] `terraform validate`が通ること
- [ ] `openai_secret_arn`未指定時に既存動作に影響がないこと
- [ ] ローカル`.env`から`OPENAI_API_KEY`が読み込まれること

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)